### PR TITLE
Typos in "The Offshore Pirate"

### DIFF
--- a/src/epub/text/the-offshore-pirate.xhtml
+++ b/src/epub/text/the-offshore-pirate.xhtml
@@ -38,7 +38,7 @@
 				<p>“Shoot!”</p>
 				<p>“Well it seems⁠—well, I am up here⁠—” He paused and swallowed several times distractedly. “Oh, yes. Young woman, Colonel Moreland has called up again to ask me to be sure to bring you in to dinner. His son Toby has come all the way from New York to meet you and he’s invited several other young people. For the last time, will you⁠—”</p>
 				<p>“No,” said Ardita shortly, “I won’t. I came along on this darn cruise with the one idea of going to Palm Beach, and you knew it, and I absolutely refuse to meet any darn old colonel or any darn young Toby or any darn old young people or to set foot in any other darn old town in this crazy state. So you either take me to Palm Beach or else shut up and go away.”</p>
-				<p>“Very well. This is the last straw. In your infatuation for this man.⁠—a man who is notorious for his excesses⁠—a man your father would not have allowed to so much as mention your name⁠—you have rejected the demimonde rather than the circles in which you have presumably grown up. From now on⁠—”</p>
+				<p>“Very well. This is the last straw. In your infatuation for this man⁠—a man who is notorious for his excesses⁠—a man your father would not have allowed to so much as mention your name⁠—you have rejected the demimonde rather than the circles in which you have presumably grown up. From now on⁠—”</p>
 				<p>“I know,” interrupted Ardita ironically, “from now on you go your way and I go mine. I’ve heard that story before. You know I’d like nothing better.”</p>
 				<p>“From now on,” he announced grandiloquently, “you are no niece of mine. I⁠—”</p>
 				<p>“O-o-o-oh!” The cry was wrung from Ardita with the agony of a lost soul. “Will you stop boring me! Will you go ’way! Will you jump overboard and drown! Do you want me to throw this book at you!”</p>
@@ -68,10 +68,10 @@
 			</section>
 			<section id="the-offshore-pirate-2" epub:type="chapter">
 				<h3 epub:type="z3998:ordinal z3998:roman">II</h3>
-				<p>Five o’clock robed down from the sun and plumped soundlessly into the sea. The golden collar widened into a glittering island; and a faint breeze that had been playing with the edges of the awning and swaying one of the dangling blue slippers became suddenly freighted with song. It was a chorus of men in close harmony and in perfect rhythm to an accompanying sound of oars dealing the blue writers. Ardita lifted her head and listened.</p>
+				<p>Five o’clock rolled down from the sun and plumped soundlessly into the sea. The golden collar widened into a glittering island; and a faint breeze that had been playing with the edges of the awning and swaying one of the dangling blue slippers became suddenly freighted with song. It was a chorus of men in close harmony and in perfect rhythm to an accompanying sound of oars dealing the blue writers. Ardita lifted her head and listened.</p>
 				<blockquote epub:type="z3998:song">
 					<p>
-						<span>“Carrots and Peas,</span>
+						<span>“Carrots and peas,</span>
 						<br/>
 						<span>Beans on their knees,</span>
 						<br/>
@@ -111,7 +111,7 @@
 				<p>With an exclamation she tossed her book to the desk, where it sprawled at a straddle, and hurried to the rail. Fifty feet away a large rowboat was approaching containing seven men, six of them rowing and one standing up in the stern keeping time to their song with an orchestra leader’s baton.</p>
 				<blockquote epub:type="z3998:song">
 					<p>
-						<span>“Oysters and Rocks,</span>
+						<span>“Oysters and rocks,</span>
 						<br/>
 						<span>Sawdust and socks,</span>
 						<br/>
@@ -135,9 +135,10 @@
 				<p>“Get off the yacht! You heard me!”</p>
 				<p>He looked at her for a moment as if considering what she had said.</p>
 				<p>“No,” said his scornful mouth slowly; “No, I won’t get off the yacht. You can get off if you wish.”</p>
-				<p>Going to the rail be gave a curt command and immediately the crew of the rowboat scrambled up the ladder and ranged themselves in line before him, a coal-black and burly darky at one end and a miniature mulatto of four feet nine at to other. They seemed to be uniformly dressed in some sort of blue costume ornamented with dust, mud, and tatters; over the shoulder of each was slung a small, heavy-looking white sack, and under their arms they carried large black cases apparently containing musical instruments.</p>
+				<p>Going to the rail he gave a curt command and immediately the crew of the rowboat scrambled up the ladder and ranged themselves in line before him, a coal-black and burly darky at one end and a miniature mulatto of four feet nine at to other. They seemed to be uniformly dressed in some sort of blue costume ornamented with dust, mud, and tatters; over the shoulder of each was slung a small, heavy-looking white sack, and under their arms they carried large black cases apparently containing musical instruments.</p>
 				<p>“ ’Ten-<em>shun</em>!” commanded the young man, snapping his own heels together crisply. “Right <em>driss</em>! Front! Step out here, Babe!”</p>
 				<p>The smallest Negro took a quick step forward and saluted.</p>
+				<p>“Yas-suh!”</p>
 				<p>“Take command, go down below, catch the crew and tie ’em up⁠—all except the engineer. Bring him up to me. Oh, and pile those bags by the rail there.”</p>
 				<p>“Yas-suh!”</p>
 				<p>Babe saluted again and wheeling about motioned for the five others to gather about him. Then after a short whispered consultation they all filed noiselessly down the companionway.</p>
@@ -149,7 +150,7 @@
 				<p>Ardita disdained to answer.</p>
 				<p>“Because inside of five minutes you’ll have to make a clear decision whether it’s go or stay.”</p>
 				<p>He picked up the book and opened it curiously.</p>
-				<p>“<i epub:type="se:name.publication.book">The Revolt of the Angels</i>. Sounds pretty good. French, eh?” He stared at her with new interest “You French?”</p>
+				<p>“<i epub:type="se:name.publication.book">The Revolt of the Angels</i>. Sounds pretty good. French, eh?” He stared at her with new interest. “You French?”</p>
 				<p>“No.”</p>
 				<p>“What’s your name?”</p>
 				<p>“Farnam.”</p>
@@ -157,7 +158,7 @@
 				<p>“Ardita Farnam.”</p>
 				<p>“Well Ardita, no use standing up there and chewing out the insides of your mouth. You ought to break those nervous habits while you’re young. Come over here and sit down.”</p>
 				<p>Ardita took a carved jade case from her pocket, extracted a cigarette and lit it with a conscious coolness, though she knew her hand was trembling a little; then she crossed over with her supple, swinging walk, and sitting down in the other settee blew a mouthful of smoke at the awning.</p>
-				<p>“You can’t get me off this yacht,” she raid steadily; “and you haven’t got very much sense if you think you’ll get far with it. My uncle’ll have wirelesses zigzagging all over this ocean by half past six.”</p>
+				<p>“You can’t get me off this yacht,” she said steadily; “and you haven’t got very much sense if you think you’ll get far with it. My uncle’ll have wirelesses zigzagging all over this ocean by half past six.”</p>
 				<p>“Hm.”</p>
 				<p>She looked quickly at his face, caught anxiety stamped there plainly in the faintest depression of the mouth’s corners.</p>
 				<p>“It’s all the same to me,” she said, shrugging her shoulders. “ ’Tisn’t my yacht. I don’t mind going for a coupla hours’ cruise. I’ll even lend you that book so you’ll have something to read on the revenue boat that takes you up to Sing-Sing.”</p>
@@ -224,7 +225,7 @@
 						<span>Yes⁠—mammy say today!”</span>
 					</p>
 				</blockquote>
-				<p>Carlyle sighed and was silent for a moment looking up at the gathered host of stars blinking like arc-lights in the warm sky. The negroes’ song had died away to a plaintive humming and it seemed as if minute by minute the brightness and the great silence were increasing until he could almost hear the midnight toilet of the mermaids as they combed their silver dripping curls under the moon and gossiped to each other of the fine wrecks they lived on the green opalescent avenues below.</p>
+				<p>Carlyle sighed and was silent for a moment looking up at the gathered host of stars blinking like arc-lights in the warm sky. The negroes’ song had died away to a plaintive humming and it seemed as if minute by minute the brightness and the great silence were increasing until he could almost hear the midnight toilet of the mermaids as they combed their silver dripping curls under the moon and gossiped to each other of the fine wrecks they lived in on the green opalescent avenues below.</p>
 				<p>“You see,” said Carlyle softly, “this is the beauty I want. Beauty has got to be astonishing, astounding⁠—it’s got to burst in on you like a dream, like the exquisite eyes of a girl.”</p>
 				<p>He turned to her, but she was silent.</p>
 				<p>“You see, don’t you, Anita⁠—I mean, Ardita?”</p>
@@ -267,8 +268,7 @@
 				<p>Ten minutes later they had swung round in a wide circle as if to approach the island from the north.</p>
 				<p>“There’s a trick somewhere,” commented Ardita thoughtfully. “He can’t mean just to anchor up against this cliff.”</p>
 				<p>They were heading straight in now toward the solid rock, which must have been well over a hundred feet tall, and not until they were within fifty yards of it did Ardita see their objective. Then she clapped her hands in delight. There was a break in the cliff entirely hidden by a curious overlapping of rock, and through this break the yacht entered and very slowly traversed a narrow channel of crystal-clear water between high gray walls. Then they were riding at anchor in a miniature world of green and gold, a gilded bay smooth as glass and set round with tiny palms, the whole resembling the mirror lakes and twig trees that children set up in sand piles.</p>
-				<p>“Not so darned bad!” cried Carlyle excitedly.</p>
-				<p>“I guess that little coon knows his way round this corner of the Atlantic.”</p>
+				<p>“Not so darned bad!” cried Carlyle excitedly. “I guess that little coon knows his way round this corner of the Atlantic.”</p>
 				<p>His exuberance was contagious, and Ardita became quite jubilant.</p>
 				<p>“It’s an absolutely sure-fire hiding-place!”</p>
 				<p>“Lordy, yes! It’s the sort of island you read about.”</p>
@@ -296,11 +296,13 @@
 				<p>“But your family disapproved, eh?”</p>
 				<p>“What there is of it⁠—only a silly uncle and a sillier aunt. It seems he got into some scandal with a red-haired woman name Mimi something⁠—it was frightfully exaggerated, he said, and men don’t lie to me⁠—and anyway I didn’t care what he’d done; it was the future that counted. And I’d see to that. When a man’s in love with me he doesn’t care for other amusements. I told him to drop her like a hot cake, and he did.”</p>
 				<p>“I feel rather jealous,” said Carlyle, frowning⁠—and then he laughed. “I guess I’ll just keep you along with us until we get to Callao. Then I’ll lend you enough money to get back to the States. By that time you’ll have had a chance to think that gentleman over a little more.”</p>
-				<p>“Don’t talk to me like that!” fired up Ardita. “I won’t tolerate the parental attitude from anybody! Do you understand me?” He chuckled and then stopped, rather abashed, as her cold anger seemed to fold him about and chill him.</p>
+				<p>“Don’t talk to me like that!” fired up Ardita. “I won’t tolerate the parental attitude from anybody! Do you understand me?”</p>
+				<p>He chuckled and then stopped, rather abashed, as her cold anger seemed to fold him about and chill him.</p>
 				<p>“I’m sorry,” he offered uncertainly.</p>
 				<p>“Oh, don’t apologize! I can’t stand men who say ‘I’m sorry’ in that manly, reserved tone. Just shut up!”</p>
 				<p>A pause ensued, a pause which Carlyle found rather awkward, but which Ardita seemed not to notice at all as she sat contentedly enjoying her cigarette and gazing out at the shining sea. After a minute she crawled out on the rock and lay with her face over the edge looking down. Carlyle, watching her, reflected how it seemed impossible for her to assume an ungraceful attitude.</p>
 				<p>“Oh, look,” she cried. “There’s a lot of sort of ledges down there. Wide ones of all different heights.”</p>
+				<p>He joined her and together they gazed down the dizzy height.</p>
 				<p>“We’ll go swimming tonight!” she said excitedly. “By moonlight.”</p>
 				<p>“Wouldn’t you rather go in at the beach on the other end?”</p>
 				<p>“Not a chance. I like to dive. You can use my uncle’s bathing suit, only it’ll fit you like a gunny sack, because he’s a very flabby man. I’ve got a one-piece that’s shocked the natives all along the Atlantic coast from Biddeford Pool to <abbr>St.</abbr> Augustine.”</p>
@@ -459,7 +461,7 @@
 				<p>And with that she turned, included the two old men, the officer, and the two sailors in a curt glance of contempt, and walked proudly down the companionway.</p>
 				<p>But had she waited an instant longer she would have heard a sound from her uncle quite unfamiliar in most of their interviews. He gave vent to a wholehearted amused chuckle, in which the second old man joined.</p>
 				<p>The latter turned briskly to Carlyle, who had been regarding this scene with an air of cryptic amusement.</p>
-				<p>“Well Toby,” he said genially, “you incurable, harebrained romantic chaser of rainbows, did you find that she was the person you wanted?”</p>
+				<p>“Well, Toby,” he said genially, “you incurable, harebrained romantic chaser of rainbows, did you find that she was the person you wanted?”</p>
 				<p>Carlyle smiled confidently.</p>
 				<p>“Why⁠—naturally,” he said, “I’ve been perfectly sure ever since I first heard tell of her wild career. That’d why I had Babe send up the rocket last night.”</p>
 				<p>“I’m glad you did,” said Colonel Moreland gravely. “We’ve been keeping pretty close to you in case you should have trouble with those six strange niggers. And we hoped we’d find you two in some such compromising position,” he sighed. “Well, set a crank to catch a crank!”</p>
@@ -472,7 +474,7 @@
 				<p>“Ardita,” he repeated breathlessly, “I’ve got to tell you the⁠—the truth. It was all a plant, Ardita. My name isn’t Carlyle. It’s Moreland, Toby Moreland. The story was invented, Ardita, invented out of thin Florida air.”</p>
 				<p>She stared at him, bewildered, amazement, disbelief, and anger flowing in quick waves across her face. The three men held their breaths. Moreland, Senior, took a step toward her; <abbr epub:type="z3998:name-title">Mr.</abbr> Farnam’s mouth dropped a little open as he waited, panic-stricken, for the expected crash.</p>
 				<p>But it did not come. Ardita’s face became suddenly radiant, and with a little laugh she went swiftly to young Moreland and looked up at him without a trace of wrath in her gray eyes.</p>
-				<p>“Will you swear,” she said quietly “That it was entirely a product of your own brain?”</p>
+				<p>“Will you swear,” she said quietly, “that it was entirely a product of your own brain?”</p>
 				<p>“I swear,” said young Moreland eagerly.</p>
 				<p>She drew his head down and kissed him gently.</p>
 				<p>“What an imagination!” she said softly and almost enviously. “I want you to lie to me just as sweetly as you know how for the rest of my life.”</p>


### PR DESCRIPTION
Fixes for numerous typos in the story "The Offshore Pirate", all from the original Gutenberg transcription. 